### PR TITLE
Gan training updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,6 @@ python -m utils.trajectory_loader _path_to_data_
 ```
 python train_forward_model.py --trajectory-length 8 --train-data-path forward_inline_data/train --gpu-id 2 --log-port 8081 --forward-save-path models/inline_task_forward
 ```
+
+## Training the GAN
+python train_gan.py --trajectory-length 8 --train-data-path forward_inline_data/train --gpu-id 2 --log-port 8081 --gan-save-path models/inline_task_gan

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ python train_forward_model.py --trajectory-length 8 --train-data-path forward_in
 ```
 
 ## Training the GAN
-python train_gan.py --trajectory-length 8 --train-data-path forward_inline_data/train --gpu-id 2 --log-port 8081 --gan-save-path models/inline_task_gan
+python train_gan.py --trajectory-length 8 --train-data-path forward_inline_data/train --evaluation-data-path forward_inline_data/eval --gpu-id 2 --log-port 8081 --gan-save-path models/inline_task_gan

--- a/control_evaluation.py
+++ b/control_evaluation.py
@@ -125,7 +125,6 @@ def fetch_push_control_evaluation(
         state_cur_fwd = state_cur[:, 0]
         image_error_sum = 0
         for image_num in range(dataset.seq_length - 1):
-            print(image_num)
 
             if image_num != dataset.seq_length - 2:
                 state_fut = state_cur[:, image_num + 1]
@@ -149,7 +148,7 @@ def fetch_push_control_evaluation(
         )
         # Cumulative action error with diverse samples
         action_error_sum += action_error
-        print(action_error_sum)
+
     avg_action_error = action_error_sum / ((dataset.seq_length - 1) * len(loader))
     avg_image_loss = image_error_sum / ((dataset.seq_length - 1) * len(loader))
 

--- a/control_evaluation.py
+++ b/control_evaluation.py
@@ -199,7 +199,9 @@ if __name__ == "__main__":
     ################################################
     gpu_id = torch.device(config.gpu_id if torch.cuda.is_available() else "cpu")
 
-    dataset = PushDataset(config.evaluation_data_path, seq_length=16)
+    dataset = PushDataset(
+        config.evaluation_data_path, seq_length=config.trajectory_length
+    )
 
     image_encoder = torch.load(config.image_encoder_model_path, map_location=gpu_id)
     generator = torch.load(config.gan_decoder_model_path, map_location=gpu_id)

--- a/train_forward_model.py
+++ b/train_forward_model.py
@@ -112,7 +112,7 @@ def train(config):
 
                 step += 1
                 loss_np = loss.cpu().data.numpy()
-            loss_np_sum += loss_np
+                loss_np_sum += loss_np
 
             if step % report_feq == 0:
 

--- a/train_forward_model.py
+++ b/train_forward_model.py
@@ -112,7 +112,7 @@ def train(config):
 
                 step += 1
                 loss_np = loss.cpu().data.numpy()
-                loss_np_sum += loss_np
+            loss_np_sum += loss_np
 
             if step % report_feq == 0:
 

--- a/train_gan.py
+++ b/train_gan.py
@@ -70,7 +70,7 @@ def train(config):
     display = visualizer(port=config.log_port)
 
     # Dataloader
-    dataset = PushDataset(config.train_data_path, seq_length=16)
+    dataset = PushDataset(config.train_data_path, seq_length=config.trajectory_length)
     loader = data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
 
     # Use pretrained image encoder

--- a/train_gan.py
+++ b/train_gan.py
@@ -70,7 +70,7 @@ def train(config):
     display = visualizer(port=config.log_port)
 
     # Dataloader
-    dataset = PushDataset(config.train_data_path, seq_length=config.trajectory_length)
+    dataset = PushDataset(config.train_data_path, seq_length=16)
     loader = data.DataLoader(dataset, batch_size=batch_size, shuffle=True)
 
     # Use pretrained image encoder


### PR DESCRIPTION
- This gets GAN training to run again with the old evaluation file
- Switches to using _config.trajectory_length_ everywhere
- Removes print statements